### PR TITLE
Fixed == -> = typo

### DIFF
--- a/examples/whisper/run.py
+++ b/examples/whisper/run.py
@@ -233,7 +233,7 @@ class WhisperTRTLLM(object):
             assert (Path(assets_dir) / "multilingual.tiktoken").exists(
             ), "multilingual.tiktoken file is not existed in assets_dir"
         else:
-            tokenizer_name == "gpt2"
+            tokenizer_name = "gpt2"
             assert (Path(assets_dir) / "gpt2.tiktoken").exists(
             ), "gpt2.tiktoken file is not existed in assets_dir"
         self.tokenizer = get_tokenizer(name=tokenizer_name,


### PR DESCRIPTION
Used to raise
```
Traceback (most recent call last):
  File "/home/jovyan/whisper/run.py", line 363, in <module>
    model = WhisperTRTLLM(args.engine_dir, args.debug, args.assets_dir)
  File "/home/jovyan/whisper/run.py", line 236, in __init__
    tokenizer_name == "gpt2"
UnboundLocalError: local variable 'tokenizer_name' referenced before assignment
```

when used with en only models